### PR TITLE
fix: 同時実行時の競合問題を修正

### DIFF
--- a/calculate_storage.py
+++ b/calculate_storage.py
@@ -56,6 +56,10 @@ class GitHubIssue:
     return computer_drives
 
   def update_issue_body(self):
+    # 最新のissue bodyとstorage_rowsを取得して、同時実行時の競合を防ぐ
+    self.body = self.__get_issue_body()
+    self.storage_rows = self.__get_storage_rows()
+    
     # self.storage_rows の内容を元に、issue の本文を更新する
     # <!-- calculate-storage#computer_name#drive --> というコメントを探して、その行を更新する
     rows = self.body.split("\n")


### PR DESCRIPTION
## 概要
Issue #9 の対応

複数のマシンで同時にアップデートを実行した際に、他のマシンのステータスが無視されてしまう問題を修正

## 変更内容
- `update_issue_body()` メソッドでissue更新時に最新のbodyを取得するよう修正
- 他のマシンの変更を保持したまま、現在のマシンのデータのみを更新する仕組みに変更
- 競合状態を回避し、複数マシンでの同時実行を安全に行えるよう改善

## テスト内容
- 既存のテストが全て通過することを確認
- Python構文チェックで構文エラーがないことを確認
- 修正した処理が正しく動作することを確認

## 修正の詳細
修正前の問題：
- オブジェクト作成時に取得したissue bodyをそのまま使用
- 他のマシンが行った変更が上書きされてしまう

修正後の改善：
- issue更新時に最新のbodyを取得
- 現在のマシンのデータのみを更新し、他のマシンのデータは保持
- 同時実行時の競合を防止

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>