### PR TITLE
fix: issue本文更新時の同時実行対応を復元

### DIFF
--- a/calculate_storage.py
+++ b/calculate_storage.py
@@ -56,6 +56,10 @@ class GitHubIssue:
     return computer_drives
 
   def update_issue_body(self):
+    # 最新のissue bodyとstorage_rowsを取得して、同時実行時の競合を防ぐ
+    self.body = self.__get_issue_body()
+    self.storage_rows = self.__get_storage_rows()
+    
     # self.storage_rows の内容を元に、issue の本文を更新する
     # <!-- calculate-storage#computer_name#drive --> というコメントを探して、その行を更新する
     rows = self.body.split("\n")


### PR DESCRIPTION
## 概要
Issue #9 の修正時に削除されてしまった同時実行対応コードを復元します。

## 問題
`update_issue_body`メソッドで、issue本文更新前に最新の状態を取得するコードが削除されていたため、同時実行時に古い情報でissue本文が更新される問題が発生していました。

## 変更内容
- `update_issue_body`メソッドの開始時に最新のissue本文とstorage_rowsを取得するロジックを復元
- 同時実行時の競合を防ぐため、更新前に必ず最新状態を取得

## テスト内容
- 実際のissue形式（`270.02 GB (58.1%)`、`🍓 ICHIGO`、`C:`など）で正常に動作することを確認
- 正規表現パターンが適切に機能することを確認
- storage_rowsの解析が正しく動作することを確認

## チェックリスト
- [x] ローカルでテストが通ることを確認
- [x] 実際のissue形式でのテストを実施
- [x] 同時実行対応ロジックを復元

🤖 Generated with [Claude Code](https://claude.ai/code)