### PR TITLE
fix: issue本文更新時にstorage_rows再取得を削除

### DIFF
--- a/calculate_storage.py
+++ b/calculate_storage.py
@@ -56,9 +56,9 @@ class GitHubIssue:
     return computer_drives
 
   def update_issue_body(self):
-    # 最新のissue bodyとstorage_rowsを取得して、同時実行時の競合を防ぐ
+    # 最新のissue bodyを取得して、同時実行時の競合を防ぐ
+    # storage_rowsは既にupdate_storage_rowで更新済みなので再取得しない
     self.body = self.__get_issue_body()
-    self.storage_rows = self.__get_storage_rows()
     
     # self.storage_rows の内容を元に、issue の本文を更新する
     # <!-- calculate-storage#computer_name#drive --> というコメントを探して、その行を更新する


### PR DESCRIPTION
## 概要
issue本文が更新されない問題を修正します。

## 問題
`update_issue_body`メソッドで`storage_rows`を再取得していたため、`update_storage_row`で更新された内容が破棄される問題が発生していました。

### 問題のフロー
1. `update_storage_row()` でメモリ上の`storage_rows`を更新（例: 50% → 90%）
2. `update_issue_body()` で最新issue本文を取得
3. **問題**: `storage_rows`を再取得 → Step 1の更新が破棄される
4. 結果: 古いデータ（50%）でissue本文が更新され、変化なし

## 修正内容
- `update_issue_body`メソッドで`storage_rows`の再取得を削除
- 最新のissue本文のみを取得し、`storage_rows`は更新済みのメモリ上データを使用
- 同時実行対応は維持しつつ、データの整合性を確保

### 修正後のフロー
1. `update_storage_row()` でメモリ上の`storage_rows`を更新（例: 50% → 90%）
2. `update_issue_body()` で最新issue本文のみ取得
3. 更新済みのメモリ上データ（90%）を使用してissue本文を更新
4. 結果: 正しく更新されたデータがissue本文に反映される

## テスト内容
- 修正前後の動作を模擬テストで確認
- storage_rowsの更新データが正しく保持されることを確認
- issue本文の更新が正常に動作することを確認

## チェックリスト
- [x] 問題の原因を特定・修正
- [x] テストで動作確認
- [x] 同時実行対応を維持
- [x] データの整合性を確保

🤖 Generated with [Claude Code](https://claude.ai/code)