### PR TITLE
chore(deps): update dependency requests to v2.34.2 and drop Python 3.9 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.x"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.x"]
 
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ sudo bash calculate-storage.sh
 .\calculate-storage.ps1
 ```
 
-CI（`.github/workflows/ci.yml`）は Ubuntu/Windows × Python 3.9〜3.13/3.x のマトリックスで上記テストコマンドを実行します。
+CI（`.github/workflows/ci.yml`）は Ubuntu/Windows × Python 3.10〜3.13/3.x のマトリックスで上記テストコマンドを実行します（`requests` が 2.33.0 以降で Python 3.9 サポートを終了したため、Python 3.9 は対象外）。
 
 ## コーディング規約
 
@@ -43,7 +43,7 @@ CI（`.github/workflows/ci.yml`）は Ubuntu/Windows × Python 3.9〜3.13/3.x �
 |---------|------|
 | `calculate_storage.py` | メインアプリケーション（単一ファイル、約 326 行） |
 | `test_calculate_storage.py` | unittest ベースのユニットテスト |
-| `requirements.txt` | 依存パッケージ（`psutil==7.2.2`, `requests==2.32.5`） |
+| `requirements.txt` | 依存パッケージ（`psutil==7.2.2`, `requests==2.34.2`） |
 | `calculate-storage.sh` / `.ps1` | Linux/Windows デプロイスクリプト |
 | `.github/workflows/ci.yml` | CI 設定 |
 | `.github/copilot-instructions.md` | GitHub Copilot コードレビュー用の指示 |


### PR DESCRIPTION
## What

Fixes the CI failure blocking Renovate PR #28 (`requests` 2.32.5 -> 2.34.2).

## Root cause

`requests` 2.33.0+ dropped Python 3.9 support (`Requires-Python >=3.10`, per requests' own changelog: "Dropped support for Python 3.9 following its end of support"). This repo's CI matrix still tests Python 3.9, so `pip install -r requirements.txt` fails with `No matching distribution found for requests==2.34.2` on the Python 3.9 jobs only (3.10-3.13/3.x all pass).

Python 3.9 itself reached upstream end-of-life on 2025-10-05.

## Fix

- Bump `requests` to `2.34.2` in `requirements.txt` (same target as PR #28).
- Drop `"3.9"` from the CI test matrix in `.github/workflows/ci.yml`.
- Update `CLAUDE.md`'s references to the supported Python range and pinned `requests` version.

No source changes were needed (no Python 3.10+-only syntax is used). All 25 unit tests pass locally against `requests==2.34.2`.

## Related

Once this merges, Renovate PR #28 should pass CI (or can be closed and Renovate can recreate an equivalent PR).