### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+data/github_token.txt
+data/


### PR DESCRIPTION
## 概要

新しい git worktree でも `data/github_token.txt`（GitHub トークン）が引き継がれるよう、`.worktreeinclude` を追加します。

## 追加したパターン

```
data/github_token.txt
data/
```

## 根拠

- `calculate_storage.py` の `get_github_token()` は `data/github_token.txt` を読み取る実装で、環境変数ではなくファイルからトークンを取得している（このファイルが無い場合は例外で停止する）。
- `CLAUDE.md` の「認証情報とデータ」セクションにも同様の記載がある。
- `.gitignore` で `data/` は除外済みで、トークンを含むこのディレクトリは通常の worktree 作成では引き継がれない。
- テンプレート・サンプルファイル（`.env.example` 等）は存在せず、README も無いため、セットアップ手順は `CLAUDE.md` にのみ記載されている。

関連: https://github.com/book000/book000/issues/132

## レビュー状況

- lite-review: 指摘事項なし
- CI: 全チェック通過
- Copilot レビュー: このリポジトリではレビュアーとして設定できませんでした（`request-review-copilot` が失敗）
